### PR TITLE
Correcting typos in config

### DIFF
--- a/VORON_Printers/Magnetic_Microswitch_Probe/Macros/homing.cfg
+++ b/VORON_Printers/Magnetic_Microswitch_Probe/Macros/homing.cfg
@@ -556,9 +556,9 @@ gcode:
 [gcode_macro Homing_ParkTool]
 gcode:
     {% set P  = printer["gcode_macro Homing_Variables"].park_toolhead      %}
-    {% set X  = printer["gcode_macro Homing_Variables"].homing__x          %}
-    {% set Y  = printer["gcode_macro Homing_Variables"].homing__y          %}
-    {% set Z  = printer["gcode_macro Homing_Variables"].Homing__z          %}
+    {% set X  = printer["gcode_macro Homing_Variables"].homing_x           %}
+    {% set Y  = printer["gcode_macro Homing_Variables"].homing_y           %}
+    {% set Z  = printer["gcode_macro Homing_Variables"].homing_z           %}
     {% set pX = printer["gcode_macro Homing_Variables"].parkposition_x     %}
     {% set pY = printer["gcode_macro Homing_Variables"].parkposition_y     %}
     {% set pZ = printer["gcode_macro Homing_Variables"].parkposition_z     %}
@@ -568,5 +568,5 @@ gcode:
     G90
     {% if not E and X and Y and Z and P %}       
         { action_respond_info("Parking Tool") }
-        G1 X{pX} Y{pY} Z{pZ} F{ printer["gcode_macro Homing_Variables"].homing_speed }
+        G1 X{pX} Y{pY} Z{pZ} F{St}
     {% endif %}


### PR DESCRIPTION
Typos in the Homing_ParkTool macro was causing it to malfunction.

Edward