### PR TITLE
Estop on probe failure by default to avoid crashes

### DIFF
--- a/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
+++ b/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
@@ -9,7 +9,7 @@
 
 # if the probe fails to attach or dock 
 # perform emergency stop 
-variable_estop_probe_failure:   False
+variable_estop_probe_failure:   True
 
 # location of the probe when docked.
 # this should typically be the coordinates


### PR DESCRIPTION
By default, we don't estop on probe failure. This can lead to crashes and as well unexpected behavior if starting printer with the probe already in place. 