### PR TITLE
update to better support Z autocalibration

### DIFF
--- a/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
+++ b/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
@@ -393,6 +393,12 @@ gcode:
         {% set Py = printer["gcode_macro Homing_Variables"].default_probe_y %}
 	    {% set Sz = printer["gcode_macro Homing_Variables"].z_drop_speed * 60 %}
 
+        #Save Gcode state incase there is a Z offset configured and the dock is mounted on the bed
+        M400 # mandatory to save the new safe position
+        #allows the docking position to be independent of the Z offset, necessary for bed mounted probes
+        SAVE_GCODE_STATE name=_doAttach
+        SET_GCODE_OFFSET Z=0
+	
         #extract from dock
         G1 X{Dxu} Y{Dyu} F{St}
         G1 X{Dxe} Y{Dye} F{St}
@@ -401,6 +407,8 @@ gcode:
         G1 Z{Dz} F{Sz}
         G1 X{Px} Y{Py} F{St} 
 
+        #reverts to the original Gcode stare
+        RESTORE_GCODE_STATE name=_doAttach
 
 [gcode_macro Dock_Probe]
 gcode:
@@ -433,7 +441,13 @@ gcode:
         {% if printer.toolhead.position.z < Dz %}
             G1 Z{Dz} F{Sz}
         {% endif %}  
-
+        
+	#Save Gcode state incase there is a Z offset configured and the dock is mounted on the bed
+        M400 # mandatory to save the new safe position
+        #allows the docking position to be independent of the Z offset, necessary for bed mounted probes
+        SAVE_GCODE_STATE name=_dockProbe
+        SET_GCODE_OFFSET Z=0
+	
         #insert into dock
         G1 X{Dxu} Y{Dyu} F{St}
         G1 X{Dxe} Y{Dye} F{St}
@@ -443,6 +457,9 @@ gcode:
 
         #check to see if probe docked
         Homing_CheckProbe action=dock 
+
+        #reverts to the original Gcode stare
+        RESTORE_GCODE_STATE name=_dockProbe
 
     {% endif %} 
 


### PR DESCRIPTION
Added save Gcode state instructions to Dock_Probe and Do_Attach to be able to dock in case of the Z autocalibration Klipper plugin configured a Z offset after auto calibration that will change the docking position and may cause a failed dock and attach.
The Z autocalibration plugin is located here https://github.com/protoloft/klipper_z_calibration

It is necessary to attach the probe, do the Z calibration (which will set a Z offset) and then dock the probe.
The problem is that Z offset may be enough to prevent the probe from docking, this PR should however solve this.
